### PR TITLE
Allow custom domain to be specified

### DIFF
--- a/src/salesforce_requests_oauthlib/__init__.py
+++ b/src/salesforce_requests_oauthlib/__init__.py
@@ -90,19 +90,28 @@ class SalesforceOAuth2Session(OAuth2Session):
                  local_server_settings=('localhost', 60443),
                  password=None,
                  ignore_cached_refresh_tokens=False,
-                 version=None):
+                 version=None,
+                 custom_domain=None):
 
         self.client_secret = client_secret
         self.username = username
         self.password = password
         self.local_server_settings = local_server_settings
-        self.token_url = token_url_template.format(
-            'test' if sandbox else 'login'
-        )
-        # Avoid name collision
-        self.authorization_url_location = authorization_url_template.format(
-            'test' if sandbox else 'login'
-        )
+        if custom_domain is not None:
+            self.token_url = token_url_template.format(
+                '{0}.my'.format(custom_domain)
+            )
+            self.authorization_url_location = authorization_url_template.format(
+                '{0}.my'.format(custom_domain)
+            )
+        else:
+            self.token_url = token_url_template.format(
+                'test' if sandbox else 'login'
+            )
+            # Avoid name collision
+            self.authorization_url_location = authorization_url_template.format(
+                'test' if sandbox else 'login'
+            )
 
         self.callback_url = 'https://{0}:{1}'.format(
             self.local_server_settings[0],


### PR DESCRIPTION
If you use lots of orgs, sometimes login.salesforce.com will send you to a domain you're already
logged into, but doesn't correspond to the username you provided.  Now you can specify a custom
domain to avoid login.salesforce.com's guesses.