### PR TITLE
fix `request()` for `method` and `url` to be keyword args, not just positional

### DIFF
--- a/src/salesforce_requests_oauthlib/__init__.py
+++ b/src/salesforce_requests_oauthlib/__init__.py
@@ -523,7 +523,7 @@ class SalesforceOAuth2Session(OAuth2Session):
 
         return to_return
 
-    def request(self, *args, **kwargs):
+    def request(self, method, url, *args, **kwargs):
         if not self.auth_flow_in_progress:
             if self.access_token is None:
                 raise WebServerFlowNeeded(
@@ -540,9 +540,6 @@ class SalesforceOAuth2Session(OAuth2Session):
         version_substitution = True
         if 'version_substitution' in kwargs:
             version_substitution = kwargs['version_substitution']
-
-        # Not checking the first two args for sanity - seems like overkill.
-        url = args[1]
 
         if version_substitution:
             if 'vXX.X' in url:
@@ -568,9 +565,9 @@ class SalesforceOAuth2Session(OAuth2Session):
                 )
 
         return super(SalesforceOAuth2Session, self).request(
-            args[0],
+            method,
             url,
-            *args[2:],
+            *args,
             **kwargs
         )
 


### PR DESCRIPTION
`request()` broke when `requests-oauthlib` made [this change](https://github.com/requests/requests-oauthlib/commit/800976faab3b827a42fa1cb80f13fcc03961d2c9), where they started calling `request()` using `method=method, url=token_url` as keyword arguments instead of positional arguments, so this change fixes it.